### PR TITLE
Play 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Play 2.6.x PDF module
+Play 2.7.x PDF module
 ===================
 ![Sonatype maven](https://img.shields.io/nexus/r/https/oss.sonatype.org/it.innove/play2-pdf.svg?style=flat)
 
@@ -27,11 +27,11 @@ Then this template, after having imported ```it.innove.PdfGenerator```, can simp
 
 	@Inject
 	public PdfGenerator pdfGenerator;
-	
+
 	public Result document() {
 		return pdfGenerator.ok(document.render("Your new application is ready."), "http://localhost:9000");
 	}
-```  
+```
 where ```pdfGenerator.ok``` is a simple shorthand notation for:
 ``` java
 	ok(pdfGenerator.toBytes(document.render("Your new application is ready."), "http://localhost:9000")).as("application/pdf")
@@ -48,8 +48,8 @@ If you specify the URI as a path into the classpath of your Play! app, the resou
 See the above sample template for an example.
 
 Of course you can link to CSS files in your class path also, but be aware not to
-use the ``` media="screen"```qualifier. 
-  
+use the ``` media="screen"```qualifier.
+
 Fonts you use must be explicitely packaged with your app.
 ```
 <html>
@@ -59,7 +59,7 @@ Fonts you use must be explicitely packaged with your app.
 			...
 			font-family: FreeSans;
 		}
-		--></style>	
+		--></style>
 	</head>
 	<body>
 		...
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
 )
 ```
 After the next restart of Play!, the module is available.
-If you are using an IDE like Eclipse, remember to re-generate your project files. 
+If you are using an IDE like Eclipse, remember to re-generate your project files.
 
 
 License

--- a/module/app/it/innove/play/pdf/PdfGenerator.java
+++ b/module/app/it/innove/play/pdf/PdfGenerator.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class PdfGenerator {
+	private static final Logger.ALogger LOG = Logger.of(PdfGenerator.class);
 
 	private List<String> defaultFonts = null;
 
@@ -56,7 +57,7 @@ public class PdfGenerator {
 				IOUtils.copy(fin, out);
 				defaultFonts.add(tempFile.getAbsolutePath());
 			} catch (Exception e) {
-				Logger.error("Loading fonts", e);
+				LOG.error("Loading fonts", e);
 			}
 		}
 	}
@@ -123,7 +124,7 @@ public class PdfGenerator {
 			renderer.layout();
 			renderer.createPDF(os);
 		} catch (Exception e) {
-			Logger.error("Error creating document from template", e);
+			LOG.error("Error creating document from template", e);
 		}
 	}
 }

--- a/module/app/it/innove/play/pdf/PdfUserAgent.java
+++ b/module/app/it/innove/play/pdf/PdfUserAgent.java
@@ -20,6 +20,7 @@ import play.Environment;
 import scala.Option;
 
 public class PdfUserAgent extends ITextUserAgent {
+	private static final Logger.ALogger LOG = Logger.of(PdfUserAgent.class);
 
 	Environment environment;
 
@@ -39,7 +40,7 @@ public class PdfUserAgent extends ITextUserAgent {
 				scaleToOutputResolution(image);
 				return new ImageResource(uri, new ITextFSImage(image));
 			} catch (Exception e) {
-				Logger.error("fetching image " + uri, e);
+				LOG.error("fetching image " + uri, e);
 				throw new RuntimeException(e);
 			}
 		} else {
@@ -57,7 +58,7 @@ public class PdfUserAgent extends ITextUserAgent {
 			new URL(uri).getPath();
 			return super.getCSSResource(uri);
 		} catch (MalformedURLException e) {
-			Logger.error("fetching css " + uri, e);
+			LOG.error("fetching css " + uri, e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -71,7 +72,7 @@ public class PdfUserAgent extends ITextUserAgent {
 			try {
 				copy(stream, baos);
 			} catch (IOException e) {
-				Logger.error("fetching binary " + uri, e);
+				LOG.error("fetching binary " + uri, e);
 				throw new RuntimeException(e);
 			}
 			return baos.toByteArray();

--- a/module/build.sbt
+++ b/module/build.sbt
@@ -6,13 +6,13 @@ version := "1.8.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.8"
 
 crossPaths := false
 
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.6",
-  "org.xhtmlrenderer" % "flying-saucer-pdf-itext5" % "9.1.11",
+  "org.xhtmlrenderer" % "flying-saucer-pdf-itext5" % "9.1.16",
   "nu.validator.htmlparser" % "htmlparser" % "1.4"
 )
 
@@ -24,7 +24,7 @@ publishMavenStyle := true
 
 publishArtifact in Test := false
 
-pomIncludeRepository := { _ => false }	
+pomIncludeRepository := { _ => false }
 
 publishTo := {
   val nexus = "https://oss.sonatype.org/"

--- a/module/project/build.properties
+++ b/module/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.2.8

--- a/module/project/plugins.sbt
+++ b/module/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")
 
 // To sign the for Sonatype
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")

--- a/samples/pdf-sample/app/controllers/Application.java
+++ b/samples/pdf-sample/app/controllers/Application.java
@@ -8,15 +8,16 @@ import okhttp3.OkHttpClient;
 import play.Logger;
 import com.typesafe.config.Config;
 import play.mvc.*;
-import play.shaded.ahc.org.asynchttpclient.util.Base64;
 import views.html.*;
 
 import java.util.Arrays;
+import java.util.Base64;
 import okhttp3.Request;
 import okhttp3.Response;
 
 public class Application extends Controller {
-	
+	private static Logger.ALogger LOG = Logger.of(Application.class);
+
 	@Inject
 	public PdfGenerator pdfGenerator;
 
@@ -32,9 +33,9 @@ public class Application extends Controller {
 		return pdfGenerator.ok(utf.render("Hello world"), configuration.getString("application.host"));
 	}
 
-	public Result pdfbase64() {
+	public Result pdfbase64(Http.Request req) {
 		Request request = new Request.Builder()
-				.url(routes.Assets.at("pdf.css").absoluteURL(request()))
+				.url(routes.Assets.at("pdf.css").absoluteURL(req))
 				.build();
 		Request requestImage = new Request.Builder()
 				.url("https://www.google.pt/images/srpr/logo11w.png")
@@ -47,12 +48,12 @@ public class Application extends Controller {
 			Response response = client.newCall(request).execute();
 			Response responseImage = client.newCall(requestImage).execute();
 			byte[] imageBytes = responseImage.body().bytes();
-			base64String = Base64.encode(imageBytes);
+			base64String = Base64.getEncoder().encodeToString(imageBytes);
 			css = response.body().string();
 
 
 		} catch (Exception ex) {
-			Logger.debug("Error",ex);
+			LOG.debug("Error",ex);
 		}
 		pdfGenerator.loadTemporaryFonts(Arrays.asList(new String[]{"fonts/OpenSans-Regular.ttf", "fonts/OpenSans-Bold.ttf"}));
 		String image = "data:image/png;base64, " + base64String;

--- a/samples/pdf-sample/build.sbt
+++ b/samples/pdf-sample/build.sbt
@@ -4,13 +4,13 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
   javaWs,
   guice,
   "it.innove" % "play2-pdf" % "1.8.0-SNAPSHOT",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.1"
+  "com.squareup.okhttp3" % "okhttp" % "3.12.1"
 )
 
 

--- a/samples/pdf-sample/conf/application.conf
+++ b/samples/pdf-sample/conf/application.conf
@@ -8,5 +8,3 @@ play.http.secret.key = "changeme"
 # The application languages
 # ~~~~~
 play.i18n.langs = [ "en" ]
-
-play.allowGlobalApplication = false

--- a/samples/pdf-sample/conf/routes
+++ b/samples/pdf-sample/conf/routes
@@ -6,7 +6,7 @@
 GET   /                controllers.Application.index
 GET   /test/pdf        controllers.Application.pdf
 GET   /utf             controllers.Application.utf
-GET   /base64          controllers.Application.pdfbase64
+GET   /base64          controllers.Application.pdfbase64(request: Request)
 
 
 # Map static resources from the /public folder to the /assets URL path

--- a/samples/pdf-sample/project/build.properties
+++ b/samples/pdf-sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.2.8

--- a/samples/pdf-sample/project/plugins.sbt
+++ b/samples/pdf-sample/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")
 
 // Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")


### PR DESCRIPTION
Static singleton Logger has been removed, so using a logger per class.
Updated the versions of Play, sbt, Scala and flying-saucer.
Updated the sample to use the java.util.Base64 class instead of the removed class from AHC and explicitly passing in the request object instead of using the deprecated request() method from context.