### PR TITLE
Use the PlayMinimalJava plugin

### DIFF
--- a/module/build.sbt
+++ b/module/build.sbt
@@ -4,7 +4,7 @@ organization := "it.innove"
 
 version := "1.9.0"
 
-lazy val root = (project in file(".")).enablePlugins(PlayJava)
+lazy val root = (project in file(".")).enablePlugins(PlayMinimalJava)
 
 scalaVersion := "2.12.8"
 


### PR DESCRIPTION
Noticed this while doing the Play 2.7 stuff, but forgot to make a pull request for it.
Since the code does not do anything with forms, we can use the PlayMinimalJava plugin to remove transitive dependencies. This way users who don't use the forms themselves either won't have to pull those dependencies in.
See the note at the bottom of https://www.playframework.com/documentation/2.7.x/JavaForms#Enabling/Disabling-the-forms-module